### PR TITLE
Fix missing distance setter

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -64,11 +64,16 @@ AddEventHandler('wasabi_boombox:soundStatus', function(type, musicId, data)
                 xSound:Position(musicId, data.position)
             end
         end
+				
         if type == "play" then
             xSound:PlayUrlPos(musicId, data.link, data.volume, data.position)
             xSound:Distance(musicId, tonumber(data.distance))
             xSound:setVolume(musicId, tonumber(data.volume))
         end
+				
+        if type == "distance" then
+            xSound:Distance(musicId, data.distance)
+        end				
 
         if type == "volume" then
             xSound:setVolume(musicId, data.volume)


### PR DESCRIPTION
I noticed that changing the distance while music was playing wasn't working. This fixes it by adding the missing type check for distance.